### PR TITLE
Improve performance by using one JVM startup instead of one-per-file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,23 +16,48 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - name: Set WebGoat workspace env var
+      run: |
+        echo "WEBGOAT_WORKSPACE=$GITHUB_WORKSPACE/WebGoat" >> $GITHUB_ENV
+
+    - name: Checkout this repository
+      uses: actions/checkout@v3
+
+    - name: Checkout WebGoat repository
+      uses: actions/checkout@v3
       with:
         repository: WebGoat/WebGoat
-
-    - uses: actions/setup-java@v1
+        path: ${{ env.WEBGOAT_WORKSPACE }}
+  
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
+        distribution: 'temurin'
         java-version: '17'
         java-package: jdk
         architecture: x64
+        cache: 'maven'
 
     - name: Delombok
-      uses: advanced-security/delombok@main
+      uses: ./
+      with:
+        src-directory: ${{ env.WEBGOAT_WORKSPACE }}
+        output-directory: ${{ env.WEBGOAT_WORKSPACE }}/src-delomboked
 
-    - run: |
-       mvn clean install -DskipTests
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: java
+        source-root: ${{ env.WEBGOAT_WORKSPACE }}
+        queries: security-extended
+        debug: true
+
+    - name: Build with Maven
+      run: mvn clean install -B -DskipTests -Dspotless.check.skip -f ${{ env.WEBGOAT_WORKSPACE }}/pom.xml
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        checkout_path: ${{ env.WEBGOAT_WORKSPACE }}
+        upload: false

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,19 @@
 name: 'Delombok.'
 description: 'Delombok the given directory'
 inputs:
-  directory:
+  src-directory:
     description: 'Path to the directory to delombok'
     required: false
     default: ${{ github.workspace }}
+  output-directory:
+    description: 'Path to the directory to write temporary delomboked files to'
+    required: false
+    default: ${{ github.workspace }}/src-delomboked
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/delombok.sh "${{ inputs.directory }}"
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: ${{ github.action_path }}/delombok.sh "${{ inputs.src-directory }}" "${{ inputs.output-directory }}"
       shell: bash

--- a/delombok.sh
+++ b/delombok.sh
@@ -8,14 +8,17 @@ if [ ! -f "$lombokjar" ]; then
   curl "https://projectlombok.org/downloads/lombok.jar" -o "$lombokjar"
 fi
 
-dir="$1"
-if [ ! -d "$dir" ]; then
-  echo 'Given path is not a directory!'
+srcDir="$1"
+if [ ! -d "$srcDir" ]; then
+  echo 'Given src path is not a directory!'
   exit 1
 fi
 
-find "$dir" -name "*.java" -type f | while read jf; do
-  python3 "${here}/delombok.py" "$jf" "$jf"
+outDir="$2"
+
+python3 "${here}/delombok.py" "$srcDir" "$outDir"
+
+find "$srcDir" -name "*.java" -type f | while read jf; do
   # Replace imports of lombok.* with lombok.NonNull, otherwise the delomboked
   # file will still be ignored by CodeQL
   sed -r -i 's/^import[[:space:]]+lombok\.\*;$/import lombok.NonNull;/g' "$jf"


### PR DESCRIPTION
The action currently iterates over all java files and spins up a new JVM to run `lombok.jar` for each file. The performance hit on this is massive so this PR makes that a single call to `lombok.jar` with a source directory instead of a single file.

Note - due to the checkout of WebGoat the `Test` workflow is unable to push code scanning results back into this repo, which is what we probably want to happen anyway give the results are for WebGoat and not this repo. The `Test` action has debug enabled for CodeQL so the results of the analysis are available as a workflow run artifact.

Comparing runs on https://github.com/ctcampbellcom/WebGoat delombok has dropped from:

<img width="1138" alt="Screenshot 2023-02-23 at 15 33 17" src="https://user-images.githubusercontent.com/808531/220954763-1f1a9e9a-757c-407a-ace0-89d354a18ca7.png">

to:

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/808531/220954953-c7fac614-5b58-4276-b21f-709bdf41005f.png">

with no impact on results found.


